### PR TITLE
Use onPremisesSecurityIdentifier for the gid/uid

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ This is a glibc NSS plugin that will query Azure Active Directory for informatio
 written in Rust. It is very, very simple, and does not even go so far as to properly use OAuth2.
 It implements the following libc functions:
 * `getpwnam`
+* `getpwuid`
 * `getgrnam`
 * `getgrgid`
 * `initgroups_dyn`
@@ -42,14 +43,16 @@ The plugin expects to read from `/etc/nssaad.conf`, which is a YAML file:
 ```yaml
 client_id: "..."
 client_secret: "..."
-tenant: "..."
 default_user_group_id: ###
+domain_sid: "S-1-5-..."
+tenant: "..."
 ```
 
 * `client_id`: is the Application ID of the [AAD Application](https://docs.microsoft.com/en-us/azure/active-directory/develop/active-directory-integrating-applications) that you have created, and to which you have granted it [the necessary permissions](https://msdn.microsoft.com/en-us/library/azure/ad/graph/howto/azure-ad-graph-api-permission-scopes) (namely, `Directory.Read.All`, or a combination of `User.ReadBasic.All` and `Group.Read.All`) to query data from the Graph API.
 * `client_secret`: is a key that the client can use to obtain an [OAuth2 bearer token](https://docs.microsoft.com/en-us/azure/active-directory/develop/active-directory-protocols-oauth-code).
-* `tenant`: is your [Azure AD tenant](https://docs.microsoft.com/en-us/azure/active-directory/develop/active-directory-howto-tenant) name, or its GUID.
 * `default_user_group_id`: is the gid that users will have by default.
+* `domain_sid`: is the domain portion of the [SID](https://en.wikipedia.org/wiki/Security_Identifier), including S-1-5- (basically any user or group SID without the relative ID at the end). NOTE: this only supports a single AD domain at the moment.
+* `tenant`: is your [Azure AD tenant](https://docs.microsoft.com/en-us/azure/active-directory/develop/active-directory-howto-tenant) name, or its GUID.
 
 ### NSS Configuration ###
 Add the `aad` service to the `/etc/nsswitch.conf` file. Probably something like:

--- a/README.md
+++ b/README.md
@@ -44,16 +44,12 @@ client_id: "..."
 client_secret: "..."
 tenant: "..."
 default_user_group_id: ###
-group_ids:
-  ...: ###
-  ...
 ```
 
 * `client_id`: is the Application ID of the [AAD Application](https://docs.microsoft.com/en-us/azure/active-directory/develop/active-directory-integrating-applications) that you have created, and to which you have granted it [the necessary permissions](https://msdn.microsoft.com/en-us/library/azure/ad/graph/howto/azure-ad-graph-api-permission-scopes) (namely, `Directory.Read.All`, or a combination of `User.ReadBasic.All` and `Group.Read.All`) to query data from the Graph API.
 * `client_secret`: is a key that the client can use to obtain an [OAuth2 bearer token](https://docs.microsoft.com/en-us/azure/active-directory/develop/active-directory-protocols-oauth-code).
 * `tenant`: is your [Azure AD tenant](https://docs.microsoft.com/en-us/azure/active-directory/develop/active-directory-howto-tenant) name, or its GUID.
 * `default_user_group_id`: is the gid that users will have by default.
-* `group_ids`: This library does not (yet) make allowances for storing GIDs in AAD. As a workaround, you must specify GIDs within the config file. The config expects a dict named `group_ids` that maps group names to GIDs:
 
 ### NSS Configuration ###
 Add the `aad` service to the `/etc/nsswitch.conf` file. Probably something like:

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ The plugin expects to read from `/etc/nssaad.conf`, which is a YAML file:
 client_id: "..."
 client_secret: "..."
 tenant: "..."
+default_user_group_id: ###
 group_ids:
   ...: ###
   ...
@@ -51,6 +52,7 @@ group_ids:
 * `client_id`: is the Application ID of the [AAD Application](https://docs.microsoft.com/en-us/azure/active-directory/develop/active-directory-integrating-applications) that you have created, and to which you have granted it [the necessary permissions](https://msdn.microsoft.com/en-us/library/azure/ad/graph/howto/azure-ad-graph-api-permission-scopes) (namely, `Directory.Read.All`, or a combination of `User.ReadBasic.All` and `Group.Read.All`) to query data from the Graph API.
 * `client_secret`: is a key that the client can use to obtain an [OAuth2 bearer token](https://docs.microsoft.com/en-us/azure/active-directory/develop/active-directory-protocols-oauth-code).
 * `tenant`: is your [Azure AD tenant](https://docs.microsoft.com/en-us/azure/active-directory/develop/active-directory-howto-tenant) name, or its GUID.
+* `default_user_group_id`: is the gid that users will have by default.
 * `group_ids`: This library does not (yet) make allowances for storing GIDs in AAD. As a workaround, you must specify GIDs within the config file. The config expects a dict named `group_ids` that maps group names to GIDs:
 
 ### NSS Configuration ###

--- a/src/azure.rs
+++ b/src/azure.rs
@@ -90,12 +90,14 @@ fn extract_user_info(userinfo: &Value) -> GraphInfoResult<UserInfo> {
         .as_str()
         .ok_or(GraphInfoRetrievalError::BadJSONResponse)?
         .to_string();
-    let user_id = userinfo["immutableId"]
+    // was immutableId
+    let mut sid_parts : Vec<&str> = userinfo["onPremisesSecurityIdentifier"]
         .as_str()
         .ok_or(GraphInfoRetrievalError::BadJSONResponse)?
-        .to_string()
-        .parse::<u32>()?;
-    if user_id == 0 {
+        .split('-').collect();
+    let user_id = sid_parts.pop().unwrap().parse::<u32>()?;
+    // rid < 1000 should only be built-in users
+    if user_id < 1000 {
         return Err(GraphInfoRetrievalError::UnusableImmutableID);
     }
 

--- a/src/azure.rs
+++ b/src/azure.rs
@@ -278,6 +278,9 @@ pub fn get_user_groups(config: &AadConfig, username: &str) -> GraphInfoResult<Ve
             Err(e) => {
                 match e {
                     GraphInfoRetrievalError::BadHTTPResponse { status, data } => {
+                        if status == hyper::status::StatusCode::NotFound {
+                            return Ok(vec![]);
+                        }
                         if data.contains("Directory_ExpiredPageToken") && retries > 0 {
                         #[cfg(debug_assertions)]
                             println!("libnss-aad::azure got an ExpiredPageToken; retrying");

--- a/src/azure.rs
+++ b/src/azure.rs
@@ -121,11 +121,20 @@ fn extract_group_info(group: &Value) -> GraphInfoResult<GroupInfo> {
         .as_str()
         .ok_or(GraphInfoRetrievalError::BadJSONResponse)?
         .to_string();
-    // we punt the question of a GID
+    let mut sid_parts : Vec<&str> = group["onPremisesSecurityIdentifier"]
+        .as_str()
+        .ok_or(GraphInfoRetrievalError::BadJSONResponse)?
+        .split('-').collect();
+    let group_id = sid_parts.pop().unwrap().parse::<u32>()?;
+    // rid < 1000 should only be built-in groups
+    if group_id < 1000 {
+        return Err(GraphInfoRetrievalError::UnusableImmutableID);
+    }
 
     Ok(GroupInfo {
            groupname: group_name,
            object_id: object_id,
+           group_id: group_id,
        })
 }
 

--- a/src/azure.rs
+++ b/src/azure.rs
@@ -282,7 +282,7 @@ pub fn get_user_groups(config: &AadConfig, username: &str) -> GraphInfoResult<Ve
                             return Ok(vec![]);
                         }
                         if data.contains("Directory_ExpiredPageToken") && retries > 0 {
-                        #[cfg(debug_assertions)]
+                            #[cfg(debug_assertions)]
                             println!("libnss-aad::azure got an ExpiredPageToken; retrying");
                             retries -= 1;
                             continue; // no kidding, this is the recommended approach.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -384,7 +384,7 @@ pub extern "C" fn _nss_aad_getgrgid_r(gid: gid_t,
     let sid = format!("{}-{}", config.domain_sid, gid);
 
     // Get the attributes of the group. Specifically we need its object ID.
-    let groupinfo = match azure::get_group_info_by_sid(&config, sid.as_str()) {
+    let groupinfo = match azure::get_group_info_by_sid(&config, &sid) {
         Ok(i) => i,
         Err(e) => {
             match e {
@@ -418,7 +418,7 @@ pub extern "C" fn _nss_aad_getgrgid_r(gid: gid_t,
         _ => vec![],
     };
 
-    match fill_group_buf(result, gid, buffer, buflen, groupinfo.groupname.as_str(), &groupmembers) {
+    match fill_group_buf(result, gid, buffer, buflen, &groupinfo.groupname, &groupmembers) {
         Ok(()) => NssStatus::Success as i32,
         Err(e) => {
             match e {
@@ -452,8 +452,7 @@ pub extern "C" fn _nss_aad_getpwuid_r(uid: uid_t,
 
     let sid = format!("{}-{}", config.domain_sid, uid);
 
-    #[allow(unused_variables)]
-    let userinfo = match azure::get_user_info_by_sid(&config, sid.as_str()) {
+    let userinfo = match azure::get_user_info_by_sid(&config, &sid) {
         Ok(i) => i,
         Err(e) => {
             match e {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,6 +66,7 @@ pub struct UserInfo {
 pub struct GroupInfo {
     groupname: String,
     object_id: String,
+    group_id: u32
 }
 
 /// The initgroups_dyn function populates a list of GIDs to which the named user belongs.
@@ -238,7 +239,7 @@ pub extern "C" fn _nss_aad_getgrnam_r(name: *const c_char,
     };
 
     match fill_group_buf(result,
-                         config.group_ids[name],
+                         groupinfo.group_id as gid_t,
                          buffer,
                          buflen,
                          name,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -116,7 +116,7 @@ pub extern "C" fn _nss_aad_initgroups_dyn(name: *const c_char,
     let user_groups: Vec<gid_t> = match azure::get_user_groups(&config, name) {
             Ok(v) => v,
             Err(err) => {
-            #[cfg(debug_assertions)]
+                #[cfg(debug_assertions)]
                 println!("libnss-aad failed to get user groups: {:?}", err);
                 return nss_entry_not_available(errnop);
             }
@@ -255,7 +255,7 @@ pub extern "C" fn _nss_aad_getgrnam_r(name: *const c_char,
             match e {
                 BufferFillError::InsufficientBuffer => nss_insufficient_buffer(errnop),
                 _ => {
-                #[cfg(debug_assertions)]
+                    #[cfg(debug_assertions)]
                     println!("libnss-aad getgrnam_r failed because {:?}", e);
                     nss_entry_not_available(errnop)
                 }
@@ -537,7 +537,7 @@ pub extern "C" fn _nss_aad_getpwnam_r(name: *const c_char,
             return nss_entry_not_available(errnop);
         }
     };
-    
+
     #[cfg(debug_assertions)]
     println!("libnss-aad getpwnam_r called for {}", name);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,6 +39,7 @@ enum NssStatus {
 pub struct AadConfig {
     client_id: String,
     client_secret: String,
+    default_user_group_id: u32,
     tenant: String,
     group_ids: HashMap<String, gid_t>,
 }
@@ -494,7 +495,7 @@ pub extern "C" fn _nss_aad_getpwnam_r(name: *const c_char,
 
     unsafe {
         (*pw).pw_uid = userinfo.userid as uid_t;
-        (*pw).pw_gid = userinfo.userid as gid_t;
+        (*pw).pw_gid = config.default_user_group_id as gid_t;
     }
 
     match fill_passwd_buf(pw, buffer, buflen, &userinfo.username, userinfo.fullname) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -92,7 +92,9 @@ pub extern "C" fn _nss_aad_initgroups_dyn(name: *const c_char,
                                           limit: size_t,
                                           errnop: *mut i32)
                                           -> i32 {
+
     assert!(!groupsp.is_null() && !name.is_null() && !start.is_null() && !size.is_null());
+
     let name = match unsafe { CStr::from_ptr(name) }.to_str() {
         Ok(s) => s,
         Err(_) => {
@@ -188,6 +190,9 @@ pub extern "C" fn _nss_aad_getgrnam_r(name: *const c_char,
                                       buflen: size_t,
                                       errnop: *mut i32)
                                       -> i32 {
+
+    assert!(!result.is_null() && !buffer.is_null() && !errnop.is_null());
+
     let name = match unsafe { CStr::from_ptr(name) }.to_str() {
         Ok(s) => s,
         Err(_) => {
@@ -374,6 +379,9 @@ pub extern "C" fn _nss_aad_getgrgid_r(gid: gid_t,
 
     assert!(!result.is_null() && !buffer.is_null() && !errnop.is_null());
 
+    #[cfg(debug_assertions)]
+    println!("libnss-aad getgrgid_r called for {}", gid);
+
     let config = match AadConfig::from_file("/etc/nssaad.conf") {
         Ok(c) => c,
         Err(_) => {
@@ -443,6 +451,11 @@ pub extern "C" fn _nss_aad_getpwuid_r(uid: uid_t,
                                       errnop: *mut i32)
                                       -> i32 {
 
+    assert!(!pw.is_null() && !buffer.is_null() && !errnop.is_null());
+
+    #[cfg(debug_assertions)]
+    println!("libnss-aad getpwuid_r called for {}", uid);
+
     let config = match AadConfig::from_file("/etc/nssaad.conf") {
         Ok(c) => c,
         Err(_) => {
@@ -508,12 +521,17 @@ pub extern "C" fn _nss_aad_getpwnam_r(name: *const c_char,
                                       errnop: *mut i32)
                                       -> i32 {
 
+    assert!(!pw.is_null() && !buffer.is_null() && !errnop.is_null());
+
     let name = match unsafe { CStr::from_ptr(name) }.to_str() {
         Ok(s) => s,
         Err(_) => {
             return nss_entry_not_available(errnop);
         }
     };
+    
+    #[cfg(debug_assertions)]
+    println!("libnss-aad getpwnam_r called for {}", name);
 
     let config = match AadConfig::from_file("/etc/nssaad.conf") {
         Ok(c) => c,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -379,6 +379,10 @@ pub extern "C" fn _nss_aad_getgrgid_r(gid: gid_t,
 
     assert!(!result.is_null() && !buffer.is_null() && !errnop.is_null());
 
+    if gid < 1000 {
+        return nss_entry_not_available(errnop);
+    }
+
     #[cfg(debug_assertions)]
     println!("libnss-aad getgrgid_r called for {}", gid);
 
@@ -452,6 +456,10 @@ pub extern "C" fn _nss_aad_getpwuid_r(uid: uid_t,
                                       -> i32 {
 
     assert!(!pw.is_null() && !buffer.is_null() && !errnop.is_null());
+
+    if uid < 1000 {
+        return nss_entry_not_available(errnop);
+    }
 
     #[cfg(debug_assertions)]
     println!("libnss-aad getpwuid_r called for {}", uid);


### PR DESCRIPTION
Currently gid isn't provided in the lookup and relies on manual mapping. The uid is derived from ImmutableId but didn't work for me (since it's the bytes of the on-prem ObjectID) and doesn't allow for an easy lookup (eg getpwuid). Instead, why not use the relative ID portion of the SID?

Possible drawbacks:
 * only works in cases where users are sync'ed from on-prem AD
 * potential collision for environments with multiple AD domains

That said, even with those two caveats, it probably covers a majority of people, and provides a nicer out of the box experience.